### PR TITLE
Add response_variable support to upload service

### DIFF
--- a/custom_components/gdrive_uploader/__init__.py
+++ b/custom_components/gdrive_uploader/__init__.py
@@ -3,6 +3,7 @@ import threading
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from homeassistant.core import SupportsResponse
 
 from .api import GDriveApi
 from .const import (
@@ -63,6 +64,7 @@ def setup(hass, config):
                 f"{DOMAIN}_{UPLOAD_COMPLETED_EVENT}",
                 {"file_id": file["id"]},
             )
+            return {"file_id": file["id"]}
         except (FileExistsError, FileNotFoundError) as error:
             _LOGGER.error(error)
             hass.bus.fire(
@@ -83,7 +85,10 @@ def setup(hass, config):
 
         threading.Thread(target=do_delete).start()
 
-    hass.services.register(DOMAIN, "upload", handle_upload)
+    hass.services.register(
+        DOMAIN, "upload", handle_upload,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
     hass.services.register(DOMAIN, "delete", handle_delete)
 
     return True


### PR DESCRIPTION
## Summary

- The `upload` service now returns `{"file_id": "..."}` as a service response, enabling automations to use `response_variable` to capture the Google Drive file ID directly
- Registered the service with `supports_response=SupportsResponse.OPTIONAL` for backward compatibility — existing automations that don't use `response_variable` continue to work unchanged
- The existing event `gdrive_uploader_upload_completed` is preserved as-is

## Usage example

```yaml
- service: gdrive_uploader.upload
  data:
    upload_file_path: "/config/www/snapshot.jpg"
    parent_id: "20BfZA1fgxxxZ4hvppPa3diltpez53aZe"
  response_variable: upload_result

- service: notify.email
  data:
    message: "File uploaded: {{ upload_result.file_id }}"
```

## Test plan

- [ ] Upload a file **without** `response_variable` — should work exactly as before (event fired, no regression)
- [ ] Upload a file **with** `response_variable` — verify the returned dict contains the correct `file_id`
- [ ] Upload a file that already exists (without `override_file`) — verify the error event still fires

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)